### PR TITLE
Add ClojureBridge to list of organizations

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,4 +22,4 @@ Sometimes it's not clear.  Good conduct requires judgment. There is a [gray area
 The following organizations are Bridge Foundry projects or partners and agree to the code of conduct above:
 
 * RailsBridge
-
+* ClojureBridge


### PR DESCRIPTION
I'm pretty sure this is right, since the http://www.clojurebridge.org/ points here.

I'd like to get positive affirmation from @bridgethillyer before this addition gets merged in.