### PR TITLE
race, age, broadened language to include online

### DIFF
--- a/anti-harrassment-policy.md
+++ b/anti-harrassment-policy.md
@@ -3,7 +3,12 @@ layout: default
 ---
 # Anti-Harassment Policy
 
-We are dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion, native language, operating system choice or prior experience. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks. Participants violating these rules may be sanctioned or expelled from an event or virtual forum at the discretion of the organizers. 
+We are dedicated to providing a harassment-free experience for everyone, 
+regardless of race, age, gender, gender identity and expression, sexual orientation, 
+disability, physical appearance, body size, race, religion, native language, operating system choice or prior experience. 
+We do not tolerate harassment of participants in any form. 
+Sexual language and imagery is not appropriate at any time, including presentations and online forums. 
+Participants violating these rules may be sanctioned or expelled from an event or virtual forum at the discretion of the organizers. 
 
 Harassment includes offensive verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion, native language, operating system choice or prior experience. 
 


### PR DESCRIPTION
feedback from participants:
- race seemed like an after-thought, so moved that forward
- age was accidentally omitted

also fixed language to include online forums and not refer to conferences (since that seemed overly specific and not relevant to most Bridge events and situations)

also split into multiple lines, since I think this will make the github diffs easier to read in the future
